### PR TITLE
Travis CI: 'sudo' tag is now deprecated in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ matrix:
       # Workaround for Python 3.7
       # https://github.com/travis-ci/travis-ci/issues/9815
       dist: xenial
-      sudo: true
       services:
         - postgresql
       addons:
@@ -25,7 +24,6 @@ matrix:
       # Workaround for Python 3.7
       # https://github.com/travis-ci/travis-ci/issues/9815
       dist: xenial
-      sudo: true
       cache:
         pip: true
       before_script:

--- a/Telegram/Telegram_Harmonbot.py
+++ b/Telegram/Telegram_Harmonbot.py
@@ -11,6 +11,7 @@ version = "0.1.4"
 # Load credentials from .env
 dotenv.load_dotenv()
 token = os.getenv("TELEGRAM_BOT_API_TOKEN")
+assert token, "Environment variable TELEGRAM_BOT_API_TOKEN is not set."
 
 bot = telegram.Bot(token = token)
 updater = telegram.ext.Updater(token = token)


### PR DESCRIPTION
[Travis are now recommending removing the __sudo__ tag](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration)